### PR TITLE
Accept message as value and return key (or error)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,10 +1681,10 @@ dependencies = [
 
 [[package]]
 name = "ssb-legacy-msg-data"
-version = "0.1.2"
-source = "git+https://github.com/mycognosist/legacy-msg-data#366306a58c751d1bdf13419313796d4e3d92cae2"
+version = "0.1.3"
+source = "git+https://github.com/sunrise-choir/legacy-msg-data#62671a1285af5765673429e39979cccb4bb5179f"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.13.0",
  "encode_unicode",
  "indexmap",
  "ryu-ecmascript",
@@ -1706,8 +1706,8 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate"
-version = "1.2.0"
-source = "git+https://github.com/mycognosist/ssb-validate#c41c7b2066e0a75fee3a00e548c55c4397f307be"
+version = "1.2.1"
+source = "git+https://github.com/sunrise-choir/ssb-validate#a7cefe3f9eab8a094e0e46431da918010f1cee3c"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1715,7 +1715,7 @@ dependencies = [
  "serde",
  "sha2 0.8.2",
  "snafu",
- "ssb-legacy-msg-data 0.1.2 (git+https://github.com/mycognosist/legacy-msg-data)",
+ "ssb-legacy-msg-data 0.1.3",
  "ssb-multiformats",
 ]
 
@@ -1724,6 +1724,7 @@ name = "ssb-validate2-rsjs-node"
 version = "0.2.0"
 dependencies = [
  "node-bindgen",
+ "ssb-legacy-msg-data 0.1.3",
  "ssb-validate",
  "ssb-verify-signatures",
 ]
@@ -1745,7 +1746,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "ssb-legacy-msg-data 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssb-legacy-msg-data 0.1.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,8 +1706,8 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate"
-version = "1.2.1"
-source = "git+https://github.com/sunrise-choir/ssb-validate#a7cefe3f9eab8a094e0e46431da918010f1cee3c"
+version = "1.4.0"
+source = "git+https://github.com/sunrise-choir/ssb-validate#f1badfbb8238ac81de4ecf7ac12cb0727f070df7"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1721,10 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate2-rsjs-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "node-bindgen",
- "ssb-legacy-msg-data 0.1.3",
  "ssb-validate",
  "ssb-verify-signatures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,7 +1667,8 @@ dependencies = [
 [[package]]
 name = "ssb-legacy-msg-data"
 version = "0.1.2"
-source = "git+https://github.com/mycognosist/legacy-msg-data#366306a58c751d1bdf13419313796d4e3d92cae2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9169f31b74aeae161e315af7da6fbc9c41a1c8b38c586d7f8df26d3eb43251"
 dependencies = [
  "base64 0.10.1",
  "encode_unicode",
@@ -1681,8 +1682,7 @@ dependencies = [
 [[package]]
 name = "ssb-legacy-msg-data"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9169f31b74aeae161e315af7da6fbc9c41a1c8b38c586d7f8df26d3eb43251"
+source = "git+https://github.com/mycognosist/legacy-msg-data#366306a58c751d1bdf13419313796d4e3d92cae2"
 dependencies = [
  "base64 0.10.1",
  "encode_unicode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate2-rsjs-node"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 
@@ -9,7 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 node-bindgen = "4.0"
-ssb-legacy-msg-data = { git = "https://github.com/sunrise-choir/legacy-msg-data" }
 ssb-validate = { git = "https://github.com/sunrise-choir/ssb-validate" }
 # update to ssb-verify-signatures = "1.0.1" when crates.io has latest
 ssb-verify-signatures = { git = "https://github.com/sunrise-choir/ssb-verify-signatures" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 node-bindgen = "4.0"
-ssb-validate = { git = "https://github.com/mycognosist/ssb-validate" }
+ssb-legacy-msg-data = { git = "https://github.com/sunrise-choir/legacy-msg-data" }
+ssb-validate = { git = "https://github.com/sunrise-choir/ssb-validate" }
 # update to ssb-verify-signatures = "1.0.1" when crates.io has latest
 ssb-verify-signatures = { git = "https://github.com/sunrise-choir/ssb-verify-signatures" }
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Cryptographic validation of Scuttlebutt messages in the form of Rust bindings fo
 
 Perform batch verification and validation of SSB message values using [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) and [ssb-validate](https://github.com/mycognosist/ssb-validate) from the [Sunrise Choir](https://github.com/sunrise-choir).
 
+**Note**: messages are expected to be values and not KVT's (`key, value, timestamp`). The key is returned for each successfully validated message.
+
 The [node-bindgen](https://github.com/infinyon/node-bindgen) crate is currently used to generate the bindings from Rust code.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cryptographic validation of Scuttlebutt messages in the form of Rust bindings for Node.js.
 
-Perform batch verification and validation of SSB messages using [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) and [ssb-validate](https://github.com/mycognosist/ssb-validate) from the [Sunrise Choir](https://github.com/sunrise-choir).
+Perform batch verification and validation of SSB message values using [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) and [ssb-validate](https://github.com/mycognosist/ssb-validate) from the [Sunrise Choir](https://github.com/sunrise-choir).
 
 The [node-bindgen](https://github.com/infinyon/node-bindgen) crate is currently used to generate the bindings from Rust code.
 
@@ -42,7 +42,7 @@ npm run perf
 
 The default values for the performance benchmarks (`test/perf.js`) are 100 messages from 1 author, for a total of 10 iterations. These value constants can be changed in `test/perf.js`. Performance benchmarks for the multi-author method default to 100 messages from 5 authors, for a total of 10 iterations (`test/multiAuthorPerf.js`).
 
-## Releasing new versions
+## Releasing New Versions
 
 To release a new version, all that you need to do is update the version number in `package.json` and commit with a message that starts with the word "release", e.g. `release 1.1.0`. Then, CI (GitHub Actions) will detect that, and compile this library for many variations of operating system and Node.js versions and then publish those as prebuilds to NPM. This repository has an environment variable `NPM_TOKEN` set up so that GitHub Actions has publish permissions for this package.
 

--- a/index.js
+++ b/index.js
@@ -8,16 +8,20 @@ const stringify = (msg) => JSON.stringify(msg, null, 2)
 const verifySignatures = (msgs, cb) => {
   if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
-  cb(v.verifySignatures(jsonMsgs));
+  const [err, result] = v.verifySignatures(jsonMsgs);
+  cb(err, result);
 };
 
 const validateSingle = (msg, previous, cb) => {
   const jsonMsg = stringify(msg);
   if (previous) {
     const jsonPrevious = stringify(previous);
-    cb(v.validateSingle(jsonMsg, jsonPrevious));
+    // `result` is a string of the hash (`key`) for the given `jsonMsg` value
+    const [err, result] = v.validateSingle(jsonMsg, jsonPrevious);
+    cb(err, result);
   } else {
-    cb(v.validateSingle(jsonMsg));
+    const [err, result] = v.validateSingle(jsonMsg);
+    cb(err, result);
   }
 };
 
@@ -26,23 +30,28 @@ const validateBatch = (msgs, previous, cb) => {
   const jsonMsgs = msgs.map(stringify);
   if (previous) {
     const jsonPrevious = stringify(previous);
-    cb(v.validateBatch(jsonMsgs, jsonPrevious));
+    // `result` is an array of strings (each string a `key`) for the given `jsonMsgs`
+    const [err, result] = v.validateBatch(jsonMsgs, jsonPrevious);
+    cb(err, result);
   } else {
-    cb(v.validateBatch(jsonMsgs));
+    const [err, result] = v.validateBatch(jsonMsgs);
+    cb(err, result);
   }
 };
 
 const validateOOOBatch = (msgs, cb) => {
   if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
-  cb(v.validateOOOBatch(jsonMsgs));
+  const [err, result] = v.validateOOOBatch(jsonMsgs);
+  cb(err, result);
 };
 
 const validateMultiAuthorBatch = (msgs, cb) => {
   if (!Array.isArray(msgs))
     throw new Error("input must be an array of message objects");
   const jsonMsgs = msgs.map(stringify);
-  cb(v.validateMultiAuthorBatch(jsonMsgs));
+  const [err, result] = v.validateMultiAuthorBatch(jsonMsgs);
+  cb(err, result);
 };
 
 // Mirrors the `ready` function for the `web` version of `ssb-validate2-rsjs`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-validate2-rsjs-node",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cryptographic validation of Scuttlebutt messages.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-validate2-rsjs-node",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Cryptographic validation of Scuttlebutt messages.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-validate2-rsjs-node",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "description": "Cryptographic validation of Scuttlebutt messages.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-validate2-rsjs-node",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Cryptographic validation of Scuttlebutt messages.",
   "main": "index.js",
   "repository": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,10 @@ use node_bindgen::derive::node_bindgen;
 use ssb_validate::{
     par_validate_message_hash_chain_of_feed, par_validate_multi_author_message_hash_chain_of_feed,
     par_validate_ooo_message_hash_chain_of_feed, validate_message_hash_chain,
-    validate_multi_author_message_hash_chain, validate_ooo_message_hash_chain,
+    validate_message_value_hash_chain, validate_multi_author_message_hash_chain,
+    validate_ooo_message_hash_chain,
 };
-use ssb_verify_signatures::{par_verify_messages, verify_message};
+use ssb_verify_signatures::{par_verify_messages, verify_message, verify_message_value};
 
 /// Verify signatures for an array of messages.
 ///
@@ -39,18 +40,18 @@ fn verify_messages(array: Vec<String>) -> Option<String> {
 
 /// Verify signature and perform validation for a single message.
 ///
-/// Takes a message as the first argument and an optional previous message as the second
+/// Takes a message `value` as the first argument and an optional previous message `value` as the second
 /// argument. The previous message argument is expected when the message to be validated is not the
 /// first in the feed (ie. sequence number != 1 and previous != null). If
 /// verification or validation fails, the cause of the error is returned along with the offending
 /// message.
 #[node_bindgen(name = "validateSingle")]
-fn verify_validate_message(message: String, previous: Option<String>) -> Option<String> {
-    let msg_bytes = message.into_bytes();
+fn verify_validate_message(msg_value: String, previous: Option<String>) -> Option<String> {
+    let msg_bytes = msg_value.into_bytes();
     let previous_msg_bytes = previous.map(|msg| msg.into_bytes());
 
     // attempt verification and match on error to find invalid message
-    match verify_message(&msg_bytes) {
+    match verify_message_value(&msg_bytes) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg_str = std::str::from_utf8(&msg_bytes).unwrap();
@@ -60,7 +61,7 @@ fn verify_validate_message(message: String, previous: Option<String>) -> Option<
     };
 
     // attempt validation and match on error to find invalid message
-    match validate_message_hash_chain(&msg_bytes, previous_msg_bytes) {
+    match validate_message_value_hash_chain(&msg_bytes, previous_msg_bytes) {
         Ok(_) => None,
         Err(e) => {
             let invalid_msg_str = std::str::from_utf8(&msg_bytes).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use node_bindgen::derive::node_bindgen;
-use ssb_legacy_msg_data::json;
 use ssb_validate::{
-    par_validate_message_hash_chain_of_feed, par_validate_multi_author_message_hash_chain_of_feed,
-    par_validate_ooo_message_hash_chain_of_feed, validate_message_hash_chain,
-    validate_message_value_hash_chain, validate_multi_author_message_hash_chain,
-    validate_ooo_message_hash_chain, SsbMessage, SsbMessageValue,
+    message_value::{
+        par_validate_message_value, par_validate_message_value_hash_chain_of_feed,
+        par_validate_ooo_message_value_hash_chain_of_feed, validate_message_value,
+        validate_message_value_hash_chain, validate_ooo_message_value_hash_chain,
+    },
+    utils,
 };
-use ssb_verify_signatures::{par_verify_messages, verify_message, verify_message_value};
+use ssb_verify_signatures::{par_verify_message_values, verify_message_value};
 
-// TODO: consider taking a Vec<msg_bytes> to allow for batch processing
-fn value_to_keyvalue(msg_bytes: &[u8]) -> String {
-    let key = ssb_validate::multihash_from_bytes(msg_bytes);
-    // should be safe to `unwrap` since we validate before calling this function
-    let value = json::from_slice::<SsbMessageValue>(msg_bytes).unwrap();
-    let kv = SsbMessage { key, value };
-    json::to_string(&kv, false).unwrap()
+fn hash(msgs: Vec<Vec<u8>>) -> Vec<String> {
+    let mut keys = Vec::new();
+    for msg in msgs {
+        let multihash = utils::multihash_from_bytes(&msg);
+        let key = multihash.to_legacy_string();
+        keys.push(key);
+    }
+    keys
 }
 
 /// Verify signatures for an array of messages.
@@ -26,7 +28,7 @@ fn value_to_keyvalue(msg_bytes: &[u8]) -> String {
 /// it does not perform full message validation (use `verify_validate_message_array` for complete
 /// verification and validation).
 #[node_bindgen(name = "verifySignatures")]
-fn verify_messages(array: Vec<String>) -> Option<String> {
+fn verify_messages(array: Vec<String>) -> (Option<String>, Option<Vec<String>>) {
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -34,29 +36,42 @@ fn verify_messages(array: Vec<String>) -> Option<String> {
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_messages(&msgs, None) {
-        Ok(_) => None,
+    match par_verify_message_values(&msgs, None) {
+        Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message(msg).is_err())
+                .find(|msg| verify_message_value(msg).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            Some(err_msg)
+            return (Some(err_msg), None);
         }
     }
+
+    let keys = hash(msgs);
+    (None, Some(keys))
 }
 
-/// Verify signature and perform validation for a single message.
+/// Verify signature and perform validation for a single message value.
 ///
 /// Takes a message `value` as the first argument and an optional previous message `value` as the second
 /// argument. The previous message argument is expected when the message to be validated is not the
-/// first in the feed (ie. sequence number != 1 and previous != null). If
-/// verification or validation fails, the cause of the error is returned along with the offending
+/// first in the feed (ie. sequence number != 1 and previous != null).
+///
+/// The return type is a tuple of `Option<String>`. The first element of the tuple holds the key
+/// (hash) of `msg_value`
+/// (if validation is successful) while the second element holds the error messages (if validation fails). Only the key for `msg_value` is returned; the key for `previous` is not.
+/// Successful validation will yield a return value of `(Some<key>, None)` - where `key` is of type
+/// `String`.
+/// Unsuccessful validation will yield a return value of `(None, Some<err_msg>)` - where `err_msg`
+/// is of type `String` and includes the cause of the error and the offending
 /// message.
 #[node_bindgen(name = "validateSingle")]
-fn verify_validate_message(msg_value: String, previous: Option<String>) -> Option<String> {
+fn verify_validate_message(
+    msg_value: String,
+    previous: Option<String>,
+) -> (Option<String>, Option<String>) {
     let msg_bytes = msg_value.into_bytes();
     let previous_msg_bytes = previous.map(|msg| msg.into_bytes());
 
@@ -66,7 +81,7 @@ fn verify_validate_message(msg_value: String, previous: Option<String>) -> Optio
         Err(e) => {
             let invalid_msg_str = std::str::from_utf8(&msg_bytes).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            return Some(err_msg);
+            return (Some(err_msg), None);
         }
     };
 
@@ -76,23 +91,28 @@ fn verify_validate_message(msg_value: String, previous: Option<String>) -> Optio
         Err(e) => {
             let invalid_msg_str = std::str::from_utf8(&msg_bytes).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            return Some(err_msg);
+            return (Some(err_msg), None);
         }
     };
 
-    // return the message as a json string of `key, value` object
-    Some(value_to_keyvalue(&msg_bytes))
+    // generate multihash from message value bytes
+    let multihash = utils::multihash_from_bytes(&msg_bytes);
+    let key = multihash.to_legacy_string();
+    (None, Some(key))
 }
 
-/// Verify signatures and perform validation for an array of ordered messages by a single author.
+/// Verify signatures and perform validation for an array of ordered message values by a single author.
 ///
-/// Takes an array of messages as the first argument and an optional previous message as the second
+/// Takes an array of message values as the first argument and an optional previous message value as the second
 /// argument. The previous message argument is expected when the array of messages does not start
 /// from the beginning of the feed (ie. sequence number != 1 and previous != null). If
 /// verification or validation fails, the cause of the error is returned along with the offending
 /// message.
 #[node_bindgen(name = "validateBatch")]
-fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Option<String> {
+fn verify_validate_messages(
+    array: Vec<String>,
+    previous: Option<String>,
+) -> (Option<String>, Option<Vec<String>>) {
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -101,33 +121,36 @@ fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Opt
 
     let previous_msg = previous.map(|msg| msg.into_bytes());
 
-    // attempt batch verification and match on error to find invalid message
-    match par_verify_messages(&msgs, None) {
+    // attempt batch verification and match on error to find invalid message value
+    match par_verify_message_values(&msgs, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message(msg).is_err())
+                .find(|msg| verify_message_value(msg).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            return Some(err_msg);
+            return (Some(err_msg), None);
         }
     };
 
-    // attempt batch validation and match on error to find invalid message
-    match par_validate_message_hash_chain_of_feed(&msgs, previous_msg.as_ref()) {
-        Ok(_) => None,
+    // attempt batch validation and match on error to find invalid message value
+    match par_validate_message_value_hash_chain_of_feed(&msgs, previous_msg.as_ref()) {
+        Ok(_) => (),
         Err(e) => {
             let invalid_message = &msgs
                 .iter()
-                .find(|msg| validate_message_hash_chain(msg, previous_msg.as_ref()).is_err())
+                .find(|msg| validate_message_value_hash_chain(msg, previous_msg.as_ref()).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_message).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            Some(err_msg)
+            return (Some(err_msg), None);
         }
     }
+
+    let keys = hash(msgs);
+    (None, Some(keys))
 }
 
 /// Verify signatures and perform validation for an array of out-of-order messages by a single
@@ -136,7 +159,9 @@ fn verify_validate_messages(array: Vec<String>, previous: Option<String>) -> Opt
 /// Takes an array of messages as the only argument. If verification or validation fails, the
 /// cause of the error is returned along with the offending message.
 #[node_bindgen(name = "validateOOOBatch")]
-fn verify_validate_out_of_order_messages(array: Vec<String>) -> Option<String> {
+fn verify_validate_out_of_order_messages(
+    array: Vec<String>,
+) -> (Option<String>, Option<Vec<String>>) {
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -144,32 +169,35 @@ fn verify_validate_out_of_order_messages(array: Vec<String>) -> Option<String> {
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_messages(&msgs, None) {
+    match par_verify_message_values(&msgs, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message(msg).is_err())
+                .find(|msg| verify_message_value(msg).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            return Some(err_msg);
+            return (Some(err_msg), None);
         }
     };
 
     // attempt batch validation and match on error to find invalid message
-    match par_validate_ooo_message_hash_chain_of_feed(&msgs) {
-        Ok(_) => None,
+    match par_validate_ooo_message_value_hash_chain_of_feed::<_, &[u8]>(&msgs, None) {
+        Ok(_) => (),
         Err(e) => {
             let invalid_message = &msgs
                 .iter()
-                .find(|msg| validate_ooo_message_hash_chain::<_, &[u8]>(msg, None).is_err())
+                .find(|msg| validate_ooo_message_value_hash_chain::<_, &[u8]>(msg, None).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_message).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            Some(err_msg)
+            return (Some(err_msg), None);
         }
     }
+
+    let keys = hash(msgs);
+    (None, Some(keys))
 }
 
 /// Verify signatures and perform validation for an array of out-of-order messages by multiple
@@ -178,7 +206,9 @@ fn verify_validate_out_of_order_messages(array: Vec<String>) -> Option<String> {
 /// Takes an array of messages as the only argument. If verification or validation fails, the
 /// cause of the error is returned along with the offending message.
 #[node_bindgen(name = "validateMultiAuthorBatch")]
-fn verify_validate_multi_author_messages(array: Vec<String>) -> Option<String> {
+fn verify_validate_multi_author_messages(
+    array: Vec<String>,
+) -> (Option<String>, Option<Vec<String>>) {
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -186,30 +216,33 @@ fn verify_validate_multi_author_messages(array: Vec<String>) -> Option<String> {
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_messages(&msgs, None) {
+    match par_verify_message_values(&msgs, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message(msg).is_err())
+                .find(|msg| verify_message_value(msg).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            return Some(err_msg);
+            return (Some(err_msg), None);
         }
     };
 
     // attempt batch validation and match on error to find invalid message
-    match par_validate_multi_author_message_hash_chain_of_feed(&msgs) {
-        Ok(_) => None,
+    match par_validate_message_value(&msgs) {
+        Ok(_) => (),
         Err(e) => {
             let invalid_message = &msgs
                 .iter()
-                .find(|msg| validate_multi_author_message_hash_chain(msg).is_err())
+                .find(|msg| validate_message_value(msg).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_message).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
-            Some(err_msg)
+            return (Some(err_msg), None);
         }
     }
+
+    let keys = hash(msgs);
+    (None, Some(keys))
 }

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -72,8 +72,9 @@ test("batch validation of out-of-order multi-author messages", (t) => {
   db.onReady(() => {
     query(
       fromDB(db),
-      toCallback((err, msgs) => {
+      toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
+        const msgs = kvtMsgs.map(msg => msg.value);
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt validation of all messages


### PR DESCRIPTION
- [x] Export message-related structs from ssb-validate (https://github.com/sunrise-choir/ssb-validate/pull/5)
  - Turns out I didn't actually need all of this but it'll probably be useful down the line
- [x] Convert `validateSingle` to take a message value instead of a KVT message
- [x] Use `ssb_validate::multihash_from_bytes(&msg_bytes)` to generate `key` from `value`
- [x] Return tuple from each Rust validation function (with `key` as `Option<Vec<String>>` and `err_msg` as `Option<String>`)
- [x] Update `index.js` to destructure returned list (tuple in Rust) to `[err, res]`, where `res` is a list holding the `key`(s)
- [x] Add OOO and multi-author support for message `value` to `ssb-validate`
- [x] Refactor multi-author and out-of-order functions to take message values
- [x] Update test(s)
- [x] Ensure CI tests pass
- [x] Do a 'lil dance

Related to https://github.com/ssb-ngi-pointer/ssb-validate2-rsjs/issues/26

Made possible by https://github.com/sunrise-choir/ssb-validate/pull/9