### PR TITLE
Introduce HMAC key support for all functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "ssb-validate2-rsjs-node"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "node-bindgen",
  "ssb-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,21 +180,6 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -1430,7 +1415,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1651,7 +1636,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b53ec8f655fb4128b3cdb9b5c981ef46944d8d95c14c958c4749aa78d2a8918d"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "curve25519-dalek",
  "ed25519-dalek",
  "hmac",
@@ -1666,25 +1651,11 @@ dependencies = [
 
 [[package]]
 name = "ssb-legacy-msg-data"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9169f31b74aeae161e315af7da6fbc9c41a1c8b38c586d7f8df26d3eb43251"
-dependencies = [
- "base64 0.10.1",
- "encode_unicode",
- "indexmap",
- "ryu-ecmascript",
- "serde",
- "serde_derive",
- "strtod2",
-]
-
-[[package]]
-name = "ssb-legacy-msg-data"
 version = "0.1.3"
-source = "git+https://github.com/sunrise-choir/legacy-msg-data#62671a1285af5765673429e39979cccb4bb5179f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e64af218ed18ae36f7b08b01ed40a0f0b8e933884221500837c51da4097de30"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "encode_unicode",
  "indexmap",
  "ryu-ecmascript",
@@ -1695,11 +1666,11 @@ dependencies = [
 
 [[package]]
 name = "ssb-multiformats"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff05b36f54bbcf7f4bbdbda7da45d75dc700e70cb42fafd7aac58bdaaafc751"
+checksum = "1664eafd1d51fdf33bb46a970c6a18d8192c371d68c022f4d5766de751a76957"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "serde",
  "ssb-crypto",
 ]
@@ -1707,7 +1678,8 @@ dependencies = [
 [[package]]
 name = "ssb-validate"
 version = "1.4.0"
-source = "git+https://github.com/sunrise-choir/ssb-validate#f1badfbb8238ac81de4ecf7ac12cb0727f070df7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8459a94bd70b827018b5186c4857853ba06c18472a282a08c3c859fe8174591"
 dependencies = [
  "lazy_static",
  "rayon",
@@ -1715,26 +1687,28 @@ dependencies = [
  "serde",
  "sha2 0.8.2",
  "snafu",
- "ssb-legacy-msg-data 0.1.3",
+ "ssb-legacy-msg-data",
  "ssb-multiformats",
 ]
 
 [[package]]
 name = "ssb-validate2-rsjs-node"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "node-bindgen",
+ "ssb-crypto",
  "ssb-validate",
  "ssb-verify-signatures",
 ]
 
 [[package]]
 name = "ssb-verify-signatures"
-version = "1.0.1"
-source = "git+https://github.com/sunrise-choir/ssb-verify-signatures#973f10918edc533db1cafe4876a7f2838289cefe"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebd0c134f3169e2af874eacb6273c03dc54d6080e7b29b3bf58adc25ea2806"
 dependencies = [
  "arrayvec",
- "base64 0.13.0",
+ "base64",
  "ed25519-dalek",
  "getrandom 0.2.3",
  "itertools",
@@ -1745,7 +1719,8 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "ssb-legacy-msg-data 0.1.2",
+ "ssb-crypto",
+ "ssb-legacy-msg-data",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate2-rsjs-node"
-version = "0.4.0"
+version = "0.5.1"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate2-rsjs-node"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 
@@ -9,9 +9,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 node-bindgen = "4.0"
-ssb-validate = { git = "https://github.com/sunrise-choir/ssb-validate" }
-# update to ssb-verify-signatures = "1.0.1" when crates.io has latest
-ssb-verify-signatures = { git = "https://github.com/sunrise-choir/ssb-verify-signatures" }
+ssb-crypto = "0.2.2"
+ssb-validate = "1.4.0"
+ssb-verify-signatures = "1.1.0"
 
 [build-dependencies]
 node-bindgen = { version = "4.0", features = ["build"] }

--- a/index.js
+++ b/index.js
@@ -5,52 +5,59 @@ const v = require('node-bindgen-loader')({
 
 const stringify = (msg) => JSON.stringify(msg, null, 2)
 
-const verifySignatures = (msgs, cb) => {
+const verifySignatures = (hmacKey, msgs, cb) => {
   if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
-  const [err, result] = v.verifySignatures(jsonMsgs);
+  // convert `null` and `undefined` to a string ("none") for easier matching in rustland
+  if (!hmacKey) hmacKey = "none";
+  const [err, result] = v.verifySignatures(hmacKey, jsonMsgs);
   cb(err, result);
 };
 
-const validateSingle = (msg, previous, cb) => {
+const validateSingle = (hmacKey, msg, previous, cb) => {
   const jsonMsg = stringify(msg);
+  // convert `null` and `undefined` to a string ("none") for easier matching in rustland
+  if (!hmacKey) hmacKey = "none";
   if (previous) {
     const jsonPrevious = stringify(previous);
     // `result` is a string of the hash (`key`) for the given `jsonMsg` value
-    const [err, result] = v.validateSingle(jsonMsg, jsonPrevious);
+    const [err, result] = v.validateSingle(hmacKey, jsonMsg, jsonPrevious);
     cb(err, result);
   } else {
-    const [err, result] = v.validateSingle(jsonMsg);
+    const [err, result] = v.validateSingle(hmacKey, jsonMsg);
     cb(err, result);
   }
 };
 
-const validateBatch = (msgs, previous, cb) => {
+const validateBatch = (hmacKey, msgs, previous, cb) => {
   if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
+  if (!hmacKey) hmacKey = "none";
   if (previous) {
     const jsonPrevious = stringify(previous);
     // `result` is an array of strings (each string a `key`) for the given `jsonMsgs`
-    const [err, result] = v.validateBatch(jsonMsgs, jsonPrevious);
+    const [err, result] = v.validateBatch(hmacKey, jsonMsgs, jsonPrevious);
     cb(err, result);
   } else {
-    const [err, result] = v.validateBatch(jsonMsgs);
+    const [err, result] = v.validateBatch(hmacKey, jsonMsgs);
     cb(err, result);
   }
 };
 
-const validateOOOBatch = (msgs, cb) => {
+const validateOOOBatch = (hmacKey, msgs, cb) => {
   if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
-  const [err, result] = v.validateOOOBatch(jsonMsgs);
+  if (!hmacKey) hmacKey = "none";
+  const [err, result] = v.validateOOOBatch(hmacKey, jsonMsgs);
   cb(err, result);
 };
 
-const validateMultiAuthorBatch = (msgs, cb) => {
+const validateMultiAuthorBatch = (hmacKey, msgs, cb) => {
   if (!Array.isArray(msgs))
     throw new Error("input must be an array of message objects");
   const jsonMsgs = msgs.map(stringify);
-  const [err, result] = v.validateMultiAuthorBatch(jsonMsgs);
+  if (!hmacKey) hmacKey = "none";
+  const [err, result] = v.validateMultiAuthorBatch(hmacKey, jsonMsgs);
   cb(err, result);
 };
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const verifySignatures = (hmacKey, msgs, cb) => {
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.verifySignatures(hmacKey, jsonMsgs);
   if (err) {
-    cb(new Error(err), result);
+    cb(new Error(err));
     return;
   }
   cb(err, result);
@@ -35,7 +35,7 @@ const validateSingle = (hmacKey, msg, previous, cb) => {
     [err, result] = v.validateSingle(hmacKey, jsonMsg);
   }
   if (err) {
-    cb(new Error(err), result);
+    cb(new Error(err));
     return;
   }
   cb(err, result);
@@ -58,7 +58,7 @@ const validateBatch = (hmacKey, msgs, previous, cb) => {
     [err, result] = v.validateBatch(hmacKey, jsonMsgs);
   }
   if (err) {
-    cb(new Error(err), result);
+    cb(new Error(err));
     return;
   }
   cb(err, result);
@@ -73,7 +73,7 @@ const validateOOOBatch = (hmacKey, msgs, cb) => {
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.validateOOOBatch(hmacKey, jsonMsgs);
   if (err) {
-    cb(new Error(err), result);
+    cb(new Error(err));
     return;
   }
   cb(err, result);
@@ -88,7 +88,7 @@ const validateMultiAuthorBatch = (hmacKey, msgs, cb) => {
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.validateMultiAuthorBatch(hmacKey, jsonMsgs);
   if (err) {
-    cb(new Error(err), result);
+    cb(new Error(err));
     return;
   }
   cb(err, result);

--- a/index.js
+++ b/index.js
@@ -6,11 +6,18 @@ const v = require('node-bindgen-loader')({
 const stringify = (msg) => JSON.stringify(msg, null, 2)
 
 const verifySignatures = (hmacKey, msgs, cb) => {
-  if (!Array.isArray(msgs)) return "input must be an array of message objects";
+  if (!Array.isArray(msgs)) {
+    cb(new Error("input must be an array of message objects"));
+    return;
+  }
   const jsonMsgs = msgs.map(stringify);
   // convert `null` and `undefined` to a string ("none") for easier matching in rustland
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.verifySignatures(hmacKey, jsonMsgs);
+  if (err) {
+    cb(new Error(err), result);
+    return;
+  }
   cb(err, result);
 };
 
@@ -18,45 +25,72 @@ const validateSingle = (hmacKey, msg, previous, cb) => {
   const jsonMsg = stringify(msg);
   // convert `null` and `undefined` to a string ("none") for easier matching in rustland
   if (!hmacKey) hmacKey = "none";
+  let err;
+  let result;
   if (previous) {
     const jsonPrevious = stringify(previous);
     // `result` is a string of the hash (`key`) for the given `jsonMsg` value
-    const [err, result] = v.validateSingle(hmacKey, jsonMsg, jsonPrevious);
-    cb(err, result);
+    [err, result] = v.validateSingle(hmacKey, jsonMsg, jsonPrevious);
   } else {
-    const [err, result] = v.validateSingle(hmacKey, jsonMsg);
-    cb(err, result);
+    [err, result] = v.validateSingle(hmacKey, jsonMsg);
   }
+  if (err) {
+    cb(new Error(err), result);
+    return;
+  }
+  cb(err, result);
 };
 
 const validateBatch = (hmacKey, msgs, previous, cb) => {
-  if (!Array.isArray(msgs)) return "input must be an array of message objects";
+  if (!Array.isArray(msgs)) {
+    cb(new Error("input must be an array of message objects"));
+    return;
+  }
   const jsonMsgs = msgs.map(stringify);
   if (!hmacKey) hmacKey = "none";
+  let err;
+  let result;
   if (previous) {
     const jsonPrevious = stringify(previous);
     // `result` is an array of strings (each string a `key`) for the given `jsonMsgs`
-    const [err, result] = v.validateBatch(hmacKey, jsonMsgs, jsonPrevious);
-    cb(err, result);
+    [err, result] = v.validateBatch(hmacKey, jsonMsgs, jsonPrevious);
   } else {
-    const [err, result] = v.validateBatch(hmacKey, jsonMsgs);
-    cb(err, result);
+    [err, result] = v.validateBatch(hmacKey, jsonMsgs);
   }
+  if (err) {
+    cb(new Error(err), result);
+    return;
+  }
+  cb(err, result);
 };
 
 const validateOOOBatch = (hmacKey, msgs, cb) => {
-  if (!Array.isArray(msgs)) return "input must be an array of message objects";
+  if (!Array.isArray(msgs)) {
+    cb(new Error("input must be an array of message objects"));
+    return;
+  }
   const jsonMsgs = msgs.map(stringify);
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.validateOOOBatch(hmacKey, jsonMsgs);
+  if (err) {
+    cb(new Error(err), result);
+    return;
+  }
   cb(err, result);
 };
 
 const validateMultiAuthorBatch = (hmacKey, msgs, cb) => {
-  if (!Array.isArray(msgs)) return "input must be an array of message objects";
+  if (!Array.isArray(msgs)) {
+    cb(new Error("input must be an array of message objects"));
+    return;
+  }
   const jsonMsgs = msgs.map(stringify);
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.validateMultiAuthorBatch(hmacKey, jsonMsgs);
+  if (err) {
+    cb(new Error(err), result);
+    return;
+  }
   cb(err, result);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-const v = require('node-bindgen-loader')({
-  moduleName: 'ssb-validate2-rsjs-node',
-  dir: __dirname
-})
+const v = require("node-bindgen-loader")({
+  moduleName: "ssb-validate2-rsjs-node",
+  dir: __dirname,
+});
 
-const stringify = (msg) => JSON.stringify(msg, null, 2)
+const stringify = (msg) => JSON.stringify(msg, null, 2);
 
 const verifySignatures = (hmacKey, msgs, cb) => {
   if (!Array.isArray(msgs)) {

--- a/index.js
+++ b/index.js
@@ -53,8 +53,7 @@ const validateOOOBatch = (hmacKey, msgs, cb) => {
 };
 
 const validateMultiAuthorBatch = (hmacKey, msgs, cb) => {
-  if (!Array.isArray(msgs))
-    throw new Error("input must be an array of message objects");
+  if (!Array.isArray(msgs)) return "input must be an array of message objects";
   const jsonMsgs = msgs.map(stringify);
   if (!hmacKey) hmacKey = "none";
   const [err, result] = v.validateMultiAuthorBatch(hmacKey, jsonMsgs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use node_bindgen::core::{buffer::JSArrayBuffer, val::JsEnv, JSValue, NjError};
 use node_bindgen::derive::node_bindgen;
+use node_bindgen::sys::napi_value;
+use ssb_crypto::{AsBytes, NetworkKey};
 use ssb_validate::{
     message_value::{
         par_validate_message_value, par_validate_message_value_hash_chain_of_feed,
@@ -10,6 +13,60 @@ use ssb_validate::{
     utils,
 };
 use ssb_verify_signatures::{par_verify_message_values, verify_message_value};
+
+// custom `enum` to allow for type conversion from js
+enum HmacKey {
+    Buf(JSArrayBuffer),
+    Str(String),
+}
+
+// implement type conversion for our custom `HmacKey` enum
+// we're primarily interested in strings and array buffers
+impl JSValue<'_> for HmacKey {
+    fn convert_to_rust(env: &JsEnv, n_value: napi_value) -> Result<Self, NjError> {
+        if let Ok(string_value) = env.convert_to_rust::<String>(n_value) {
+            Ok(Self::Str(string_value))
+        } else if let Ok(buffer_value) = env.convert_to_rust::<JSArrayBuffer>(n_value) {
+            Ok(Self::Buf(buffer_value))
+        } else {
+            Err(NjError::Other(
+                "hmacKey must be of type string, array buffer, null or undefined".to_owned(),
+            ))
+        }
+    }
+}
+
+// the `Ok()` variant for `Result` represents a valid hmac key value as a byte vector
+fn is_valid_hmac_key(hmac_key: HmacKey) -> Result<Option<Vec<u8>>, String> {
+    match hmac_key {
+        HmacKey::Buf(hmac) => {
+            let key = NetworkKey::from_slice(&hmac);
+            match key {
+                None => Err("hmac key invalid: byte length must equal 32".to_string()),
+                Some(key_val) => {
+                    let key_bytes = key_val.as_bytes().to_vec();
+                    Ok(Some(key_bytes))
+                }
+            }
+        }
+        HmacKey::Str(hmac) => {
+            let key = NetworkKey::from_base64(&hmac);
+            // match on what would have been `null` or `undefined` for `hmacKey`
+            // in the js function call. these values are considered valid.
+            if hmac == "none" {
+                Ok(None)
+            } else {
+                match key {
+                    None => Err("hmac key invalid: string must be base64 encoded".to_string()),
+                    Some(key_val) => {
+                        let key_bytes = key_val.as_bytes().to_vec();
+                        Ok(Some(key_bytes))
+                    }
+                }
+            }
+        }
+    }
+}
 
 fn hash(msgs: Vec<Vec<u8>>) -> Vec<String> {
     let mut keys = Vec::new();
@@ -21,14 +78,23 @@ fn hash(msgs: Vec<Vec<u8>>) -> Vec<String> {
     keys
 }
 
-/// Verify signatures for an array of messages.
+/// Verify signatures for an array of messages (includes HMAC key support).
 ///
-/// Takes an array of messages as the only argument. If verification fails, the cause of the error
-/// is returned along with the offending message. Note: this method only verifies message signatures;
-/// it does not perform full message validation (use `verify_validate_message_array` for complete
-/// verification and validation).
+/// Takes an HMAC key as the first argument and an array of messages as the second argument.
+/// The HMAC key must be of type `string` or `ArrayBuffer`. Message signatures are verified without
+/// an HMAC key if the value of the argument is a `string` with value `none`.
+///
+/// If verification fails, the cause of the error is returned along with the offending message.
+/// Note: this method only verifies message signatures; it does not perform full message validation
+/// (use `verify_validate_message_array` for complete verification and validation).
 #[node_bindgen(name = "verifySignatures")]
-fn verify_messages(array: Vec<String>) -> (Option<String>, Option<Vec<String>>) {
+fn verify_messages(hmac_key: HmacKey, array: Vec<String>) -> (Option<String>, Option<Vec<String>>) {
+    let valid_hmac = match is_valid_hmac_key(hmac_key) {
+        Ok(key) => key,
+        Err(err_msg) => return (Some(err_msg), None),
+    };
+    let hmac = valid_hmac.as_deref();
+
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -36,12 +102,12 @@ fn verify_messages(array: Vec<String>) -> (Option<String>, Option<Vec<String>>) 
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_message_values(&msgs, None) {
+    match par_verify_message_values(&msgs, hmac, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message_value(msg).is_err())
+                .find(|msg| verify_message_value(msg, hmac).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
@@ -53,30 +119,39 @@ fn verify_messages(array: Vec<String>) -> (Option<String>, Option<Vec<String>>) 
     (None, Some(keys))
 }
 
-/// Verify signature and perform validation for a single message value.
+/// Verify signature and perform validation for a single message value (includes HMAC key support).
 ///
-/// Takes a message `value` as the first argument and an optional previous message `value` as the second
-/// argument. The previous message argument is expected when the message to be validated is not the
-/// first in the feed (ie. sequence number != 1 and previous != null).
+/// Takes an HMAC key as the first argument, message `value` as the second argument and an optional
+/// previous message `value` as the third argument. The HMAC key must be of type `string` or
+/// `ArrayBuffer`. Message signatures are verified without an HMAC key if the value of the argument
+/// is a `string` with value `none`. The previous message argument is expected when the message to
+/// be validated is not the first in the feed (ie. sequence number != 1 and previous != null).
 ///
 /// The return type is a tuple of `Option<String>`. The first element of the tuple holds the key
-/// (hash) of `msg_value`
-/// (if validation is successful) while the second element holds the error messages (if validation fails). Only the key for `msg_value` is returned; the key for `previous` is not.
+/// (hash) of `msg_value` (if validation is successful) while the second element holds the error
+/// messages (if validation fails). Only the key for `msg_value` is returned; the key for `previous`
+/// is not.
+///
 /// Successful validation will yield a return value of `(Some<key>, None)` - where `key` is of type
-/// `String`.
-/// Unsuccessful validation will yield a return value of `(None, Some<err_msg>)` - where `err_msg`
-/// is of type `String` and includes the cause of the error and the offending
-/// message.
+/// `String`. Unsuccessful validation will yield a return value of `(None, Some<err_msg>)` - where
+/// `err_msg` is of type `String` and includes the cause of the error and the offending message.
 #[node_bindgen(name = "validateSingle")]
 fn verify_validate_message(
+    hmac_key: HmacKey,
     msg_value: String,
     previous: Option<String>,
 ) -> (Option<String>, Option<String>) {
+    let valid_hmac = match is_valid_hmac_key(hmac_key) {
+        Ok(key) => key,
+        Err(err_msg) => return (Some(err_msg), None),
+    };
+    let hmac = valid_hmac.as_deref();
+
     let msg_bytes = msg_value.into_bytes();
     let previous_msg_bytes = previous.map(|msg| msg.into_bytes());
 
     // attempt verification and match on error to find invalid message
-    match verify_message_value(&msg_bytes) {
+    match verify_message_value(&msg_bytes, hmac) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg_str = std::str::from_utf8(&msg_bytes).unwrap();
@@ -101,18 +176,28 @@ fn verify_validate_message(
     (None, Some(key))
 }
 
-/// Verify signatures and perform validation for an array of ordered message values by a single author.
+/// Verify signatures and perform validation for an array of ordered message values by a single
+/// author (includes HMAC key support).
 ///
-/// Takes an array of message values as the first argument and an optional previous message value as the second
-/// argument. The previous message argument is expected when the array of messages does not start
-/// from the beginning of the feed (ie. sequence number != 1 and previous != null). If
-/// verification or validation fails, the cause of the error is returned along with the offending
-/// message.
+/// Takes an HMAC key as the first argument, an array of message values as the second argument
+/// and an optional previous message value as the third argument. The HMAC key must be of type
+/// `string` or `ArrayBuffer`. Message signatures are verified without an HMAC key if the value
+/// of the argument is a `string` with value `none`. The previous message argument is expected
+/// when the array of messages does not start from the beginning of the feed (ie. sequence number
+/// != 1 and previous != null). If verification or validation fails, the cause of the error is
+/// returned along with the offending message.
 #[node_bindgen(name = "validateBatch")]
 fn verify_validate_messages(
+    hmac_key: HmacKey,
     array: Vec<String>,
     previous: Option<String>,
 ) -> (Option<String>, Option<Vec<String>>) {
+    let valid_hmac = match is_valid_hmac_key(hmac_key) {
+        Ok(key) => key,
+        Err(err_msg) => return (Some(err_msg), None),
+    };
+    let hmac = valid_hmac.as_deref();
+
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -122,12 +207,12 @@ fn verify_validate_messages(
     let previous_msg = previous.map(|msg| msg.into_bytes());
 
     // attempt batch verification and match on error to find invalid message value
-    match par_verify_message_values(&msgs, None) {
+    match par_verify_message_values(&msgs, hmac, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message_value(msg).is_err())
+                .find(|msg| verify_message_value(msg, hmac).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
@@ -154,14 +239,24 @@ fn verify_validate_messages(
 }
 
 /// Verify signatures and perform validation for an array of out-of-order messages by a single
-/// author.
+/// author (includes HMAC key support).
 ///
-/// Takes an array of messages as the only argument. If verification or validation fails, the
-/// cause of the error is returned along with the offending message.
+/// Takes an HMAC key as the first argument and an array of messages as the second argument.
+/// The HMAC key must be of type `string` or `ArrayBuffer`. Message signatures are verified
+/// without an HMAC key if the value of the argument is a `string` with value `none`. If
+/// verification or validation fails, the cause of the error is returned along with the
+/// offending message.
 #[node_bindgen(name = "validateOOOBatch")]
 fn verify_validate_out_of_order_messages(
+    hmac_key: HmacKey,
     array: Vec<String>,
 ) -> (Option<String>, Option<Vec<String>>) {
+    let valid_hmac = match is_valid_hmac_key(hmac_key) {
+        Ok(key) => key,
+        Err(err_msg) => return (Some(err_msg), None),
+    };
+    let hmac = valid_hmac.as_deref();
+
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -169,12 +264,12 @@ fn verify_validate_out_of_order_messages(
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_message_values(&msgs, None) {
+    match par_verify_message_values(&msgs, hmac, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message_value(msg).is_err())
+                .find(|msg| verify_message_value(msg, hmac).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);
@@ -201,14 +296,23 @@ fn verify_validate_out_of_order_messages(
 }
 
 /// Verify signatures and perform validation for an array of out-of-order messages by multiple
-/// authors.
+/// authors (includes HMAC key support).
 ///
-/// Takes an array of messages as the only argument. If verification or validation fails, the
-/// cause of the error is returned along with the offending message.
+/// Takes an HMAC key as the first argument and an array of messages as the second argument. The
+/// HMAC key must be of type `string` or `ArrayBuffer`. Message signatures are verified without
+/// an HMAC key if the value of the argument is a `string` with value `none`. If  verification
+/// or validation fails, the cause of the error is returned along with the offending message.
 #[node_bindgen(name = "validateMultiAuthorBatch")]
 fn verify_validate_multi_author_messages(
+    hmac_key: HmacKey,
     array: Vec<String>,
 ) -> (Option<String>, Option<Vec<String>>) {
+    let valid_hmac = match is_valid_hmac_key(hmac_key) {
+        Ok(key) => key,
+        Err(err_msg) => return (Some(err_msg), None),
+    };
+    let hmac = valid_hmac.as_deref();
+
     let mut msgs = Vec::new();
     for msg in array {
         let msg_bytes = msg.into_bytes();
@@ -216,12 +320,12 @@ fn verify_validate_multi_author_messages(
     }
 
     // attempt batch verification and match on error to find invalid message
-    match par_verify_message_values(&msgs, None) {
+    match par_verify_message_values(&msgs, hmac, None) {
         Ok(_) => (),
         Err(e) => {
             let invalid_msg = &msgs
                 .iter()
-                .find(|msg| verify_message_value(msg).is_err())
+                .find(|msg| verify_message_value(msg, hmac).is_err())
                 .unwrap();
             let invalid_msg_str = std::str::from_utf8(invalid_msg).unwrap();
             let err_msg = format!("found invalid message: {}: {}", e, invalid_msg_str);

--- a/test/multiAuthorPerf.js
+++ b/test/multiAuthorPerf.js
@@ -35,6 +35,8 @@ const AUTHORS = 5;
 // run each test x times
 const ITERATIONS = 10;
 
+const hmacKey = null;
+
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({
     outputDir: dir,
@@ -89,7 +91,7 @@ test("validateMultiAuthorBatch", (t) => {
           // shuffle array of msgs to generate out-of-order state
           msgs.sort(() => Math.random() - 0.5);
           const start = Date.now();
-          validate.validateMultiAuthorBatch(msgs, () => {
+          validate.validateMultiAuthorBatch(hmacKey, msgs, () => {
             const duration = Date.now() - start;
             totalDuration += duration;
             t.pass(`validated ${MESSAGES} messages in ${duration} ms`);
@@ -114,12 +116,11 @@ test("append (legacy validation)", (t) => {
         var i;
         var totalDuration = 0;
         for (i = 0; i < ITERATIONS; i++) {
-          var hmac_key = null;
           var state = legacyValidate.initial();
           const start = Date.now();
           msgs.forEach(function (msg) {
             try {
-              state = legacyValidate.append(state, hmac_key, msg);
+              state = legacyValidate.append(state, hmacKey, msg);
             } catch (err) {
               console.log(err);
             }

--- a/test/multiAuthorTest.js
+++ b/test/multiAuthorTest.js
@@ -32,6 +32,8 @@ const SEED = "sloop";
 const MESSAGES = 10;
 const AUTHORS = 2;
 
+const hmacKey = null;
+
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({
     outputDir: dir,
@@ -74,15 +76,15 @@ test("batch validation of out-of-order multi-author messages", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt validation of all messages
-        validate.validateMultiAuthorBatch(msgs, (err) => {
+        validate.validateMultiAuthorBatch(hmacKey, msgs, (err) => {
           t.equal(err, null, "success");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });

--- a/test/perf.js
+++ b/test/perf.js
@@ -35,6 +35,8 @@ const AUTHORS = 1;
 // run each test x times
 const ITERATIONS = 10;
 
+const hmacKey = null;
+
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({
     outputDir: dir,
@@ -87,7 +89,7 @@ test("verifySignatures", (t) => {
         var totalDuration = 0;
         for (i = 0; i < ITERATIONS; i++) {
           const start = Date.now();
-          validate.verifySignatures(msgs, () => {
+          validate.verifySignatures(hmacKey, msgs, () => {
             const duration = Date.now() - start;
             totalDuration += duration;
             t.pass(`verified ${MESSAGES} message signatures in ${duration} ms`);
@@ -114,7 +116,7 @@ test("validateSingle", (t) => {
         for (i = 0; i < ITERATIONS; i++) {
           // validate a single message (`seq` == 1)
           const start = Date.now();
-          validate.validateSingle(kvtMsgs[0].value, null, () => {
+          validate.validateSingle(hmacKey, kvtMsgs[0].value, null, () => {
             const duration = Date.now() - start;
             totalDuration += duration;
             t.pass(`validated 1 message in ${duration} ms`);
@@ -143,7 +145,7 @@ test("validateBatch", (t) => {
         for (i = 0; i < ITERATIONS; i++) {
           // validate array of successive messages from a feed
           const start = Date.now();
-          validate.validateBatch(msgs, null, () => {
+          validate.validateBatch(hmacKey, msgs, null, () => {
             const duration = Date.now() - start;
             totalDuration += duration;
             t.pass(`validated ${MESSAGES} messages in ${duration} ms`);
@@ -173,7 +175,7 @@ test("validateOOOBatch", (t) => {
           const start = Date.now();
           // shuffle array of msgs to generate out-of-order state
           msgs.sort(() => Math.random() - 0.5);
-          validate.validateOOOBatch(msgs, () => {
+          validate.validateOOOBatch(hmacKey, msgs, () => {
             const duration = Date.now() - start;
             totalDuration += duration;
             t.pass(`validated ${MESSAGES} messages in ${duration} ms`);
@@ -198,12 +200,11 @@ test("append (legacy validation)", (t) => {
         var i;
         var totalDuration = 0;
         for (i = 0; i < ITERATIONS; i++) {
-          var hmac_key = null;
           var state = legacyValidate.initial();
           const start = Date.now();
           msgs.forEach(function (msg) {
             try {
-              state = legacyValidate.append(state, hmac_key, msg);
+              state = legacyValidate.append(state, hmacKey, msg);
             } catch (err) {
               console.log(err);
             }

--- a/test/test.js
+++ b/test/test.js
@@ -62,14 +62,6 @@ const hmacMsg = {
 const hmacKey = null;
 const hmacVal = "CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U=";
 
-function toBuffer(buf) {
-  if (buf == null) return buf;
-  if (Buffer.isBuffer(buf)) return buf;
-  var i = buf.indexOf(".");
-  var start = hasSigil(buf) ? 1 : 0;
-  return Buffer.from(buf.substring(start, ~i ? i : buf.length), "base64");
-}
-
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({
     outputDir: dir,

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,28 @@ const validMsg = {
     "PkZ34BRVSmGG51vMXo4GvaoS/2NBc0lzdFoVv4wkI8E8zXv4QYyE5o2mPACKOcrhrLJpymLzqpoE70q78INuBg==.sig.ed25519",
 };
 
+const hmacMsg = {
+  previous: null,
+  sequence: 1,
+  author: "@EnPSnV1HZdyE7pcKxqukyhmnwE9076RtAlYclaUMX5g=.ed25519",
+  timestamp: 1624360181359,
+  hash: "sha256",
+  content: { type: "example" },
+  signature:
+    "w670wqnD1A5blFaYxDiIhPOTwz8I7syVx30jac1feQK/OywHFfrcLVw2S1KmxK9GzWxvKxLMle/jKjf2+pHtAg==.sig.ed25519",
+};
+
+const hmacKey = null;
+const hmacVal = "CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U=";
+
+function toBuffer(buf) {
+  if (buf == null) return buf;
+  if (Buffer.isBuffer(buf)) return buf;
+  var i = buf.indexOf(".");
+  var start = hasSigil(buf) ? 1 : 0;
+  return Buffer.from(buf.substring(start, ~i ? i : buf.length), "base64");
+}
+
 test("generate fixture with flumelog-offset", (t) => {
   generateFixture({
     outputDir: dir,
@@ -91,9 +113,9 @@ test("batch verification of message signatures", (t) => {
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
         // map msgs to msg.value for each
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // attempt verification of all messages
-        validate.verifySignatures(msgs, (err, res) => {
+        validate.verifySignatures(hmacKey, msgs, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
@@ -109,15 +131,15 @@ test("batch verification of out-of-order message signatures", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt verification of all messages
-        validate.verifySignatures(msgs, (err, res) => {
+        validate.verifySignatures(hmacKey, msgs, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -125,26 +147,44 @@ test("batch verification of out-of-order message signatures", (t) => {
 
 test("verification of single message signature (valid)", (t) => {
   let msgs = [validMsg];
-  validate.verifySignatures(msgs, (err, res) => {
+  validate.verifySignatures(hmacKey, msgs, (err, res) => {
     t.equal(err, null, "success: err is null");
-    t.deepEqual(res, [ '%kmXb3MXtBJaNugcEL/Q7G40DgcAkMNTj3yhmxKHjfCM=.sha256' ], "success: returned key is correct");
+    t.deepEqual(
+      res,
+      ["%kmXb3MXtBJaNugcEL/Q7G40DgcAkMNTj3yhmxKHjfCM=.sha256"],
+      "success: returned key is correct"
+    );
     t.pass(`validated ${MESSAGES} messages`);
     t.end();
-  })
+  });
 });
 
 test("verification of single message signature (invalid)", (t) => {
   let invalidMsg = validMsg;
   invalidMsg.content.following = false;
   let msgs = [invalidMsg];
-  validate.verifySignatures(msgs, (err, res) => {
+  validate.verifySignatures(hmacKey, msgs, (err, res) => {
     t.match(
       err,
       /Signature was invalid/,
       "found invalid message: Signature was invalid"
     );
     t.end();
-  })
+  });
+});
+
+test("verification of single message signature with hmac", (t) => {
+  let msgs = [hmacMsg];
+  validate.verifySignatures(hmacVal, msgs, (err, res) => {
+    t.equal(err, null, "success: err is null");
+    t.deepEqual(
+      res,
+      ["%8RL6pJ+3zdcX4v9wv3inbWzlnQH7ZV4Hi0Nvzdfibu0=.sha256"],
+      "success: returned key is correct"
+    );
+    t.pass(`validated ${MESSAGES} messages`);
+    t.end();
+  });
 });
 
 test("validation of first message (`seq` == 1) without `previous`", (t) => {
@@ -153,14 +193,14 @@ test("validation of first message (`seq` == 1) without `previous`", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // attempt validation of single message (assume `previous` is null)
-        validate.validateSingle(msgs[0], null, (err, res) => {
+        validate.validateSingle(hmacKey, msgs[0], null, (err, res) => {
           t.equal(err, null, "success: err is null");
           // maybe we can check the key here somehow? (res) is-canonical-base64 maybe?
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -172,13 +212,13 @@ test("validation of a single message with `previous`", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // attempt validation of single message (include previous message)
-        validate.validateSingle(msgs[1], msgs[0], (err, res) => {
+        validate.validateSingle(hmacKey, msgs[1], msgs[0], (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -190,18 +230,70 @@ test("validation of a single message (`seq` > 1) without `previous`", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // attempt validation of a single message without `previous`
-        validate.validateSingle(msgs[3], null, (err, res) => {
+        validate.validateSingle(hmacKey, msgs[3], null, (err, res) => {
           t.match(
             err,
             /The first message of a feed must have seq of 1/,
             "found invalid message: The first message of a feed must have seq of 1"
           );
           t.end();
-        })
+        });
       })
     );
+  });
+});
+
+test("validation of a single message with hmac (without `previous`)", (t) => {
+  validate.validateSingle(hmacVal, hmacMsg, null, (err, res) => {
+    t.equal(err, null, "success: err is null");
+    t.equal(
+      res,
+      "%8RL6pJ+3zdcX4v9wv3inbWzlnQH7ZV4Hi0Nvzdfibu0=.sha256",
+      "success: returned key is correct"
+    );
+    t.pass(`validated ${MESSAGES} messages`);
+    t.end();
+  });
+});
+
+test("validation of a single message with hmac as buffer (without `previous`)", (t) => {
+  let hmacBuf = Buffer.from(
+    "CbwuwYXmZgN7ZSuycCXoKGOTU1dGwBex+paeA2kr37U",
+    "base64"
+  );
+  validate.validateSingle(hmacBuf, hmacMsg, null, (err, res) => {
+    t.equal(err, null, "success: err is null");
+    t.equal(
+      res,
+      "%8RL6pJ+3zdcX4v9wv3inbWzlnQH7ZV4Hi0Nvzdfibu0=.sha256",
+      "success: returned key is correct"
+    );
+    t.pass(`validated ${MESSAGES} messages`);
+    t.end();
+  });
+});
+
+test("validation of a single hmac'd message without hmac key", (t) => {
+  validate.validateSingle(hmacKey, hmacMsg, null, (err, res) => {
+    t.match(
+      err,
+      /Signature was invalid/,
+      "found invalid message: Signature was invalid"
+    );
+    t.end();
+  });
+});
+
+test("validation of a single hmac'd message with invalid hmac key", (t) => {
+  validate.validateSingle("isnotvalid", hmacMsg, null, (err, res) => {
+    t.match(
+      err,
+      /string must be base64 encoded/,
+      "hmac key invalid: string must be base64 encoded"
+    );
+    t.end();
   });
 });
 
@@ -211,13 +303,13 @@ test("batch validation of full feed", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // attempt validation of all messages (assume `previous` is null)
-        validate.validateBatch(msgs, null, (err, res) => {
+        validate.validateBatch(hmacKey, msgs, null, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -229,15 +321,15 @@ test("batch validation of partial feed (previous seq == 1)", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // shift first msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages
-        validate.validateBatch(msgs, previous, (err, res) => {
+        validate.validateBatch(hmacKey, msgs, previous, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -249,17 +341,17 @@ test("batch validation of partial feed (previous seq > 1)", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // skip first msg in the array
         first = msgs.shift();
         // shift second msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages
-        validate.validateBatch(msgs, previous, (err, res) => {
+        validate.validateBatch(hmacKey, msgs, previous, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });
@@ -271,18 +363,18 @@ test("batch validation of partial feed without `previous`", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // shift first msg into `previous`
         previous = msgs.shift();
         // attempt validation of all messages without `previous`
-        validate.validateBatch(msgs, null, (err, res) => {
+        validate.validateBatch(hmacKey, msgs, null, (err, res) => {
           t.match(
             err,
             /The first message of a feed must have seq of 1/,
             "found invalid message: The first message of a feed must have seq of 1"
           );
           t.end();
-        })
+        });
       })
     );
   });
@@ -294,15 +386,15 @@ test("batch validation of out-of-order messages", (t) => {
       fromDB(db),
       toCallback((err, kvtMsgs) => {
         if (err) t.fail(err);
-        const msgs = kvtMsgs.map(msg => msg.value);
+        const msgs = kvtMsgs.map((msg) => msg.value);
         // shuffle the messages (generate out-of-order state)
         msgs.sort(() => Math.random() - 0.5);
         // attempt validation of all messages
-        validate.validateOOOBatch(msgs, (err, res) => {
+        validate.validateOOOBatch(hmacKey, msgs, (err, res) => {
           t.equal(err, null, "success: err is null");
           t.pass(`validated ${MESSAGES} messages`);
           t.end();
-        })
+        });
       })
     );
   });


### PR DESCRIPTION
Introduces support for verifying message signatures with the provided HMAC key. This has been made possible by updated capabilities in the [ssb-verify-signatures crate](https://crates.io/crates/ssb-verify-signatures).

**Changes**

 - All methods now accept `hmacKey` as a **required** first parameter
   - May be `null`, `undefined`, `string` or `Buffer`
   - `null` and `undefined` values are converted to a `string` with value `none` in `index.js` (allows easier matching in Rust)
 - Manifest now specifies crates.io version numbers for all ssb dependencies (no longer using git paths)
 - Doc comments added / updated for all of the main `src/lib.rs` functions
 - Node tests and performance benchmarks have been added for HMAC support
 - Repo version has been bumped to `0.4.0`
 
**Example Usage**

```javascript
const hmacKey = null;
v.verifySignatures(hmacKey, [msg], (err, res) => { console.log(err); console.log(res); });
```

 All tests and benchmarks are passing.